### PR TITLE
removing commented out code and NSLogs, using documentation comments,…

### DIFF
--- a/DenverRail/AppDelegate.h
+++ b/DenverRail/AppDelegate.h
@@ -6,28 +6,15 @@
 //
 
 #import <UIKit/UIKit.h>
-#import "TestFlight.h"
-
-@class BaseViewController, WhistleBlowerController;
 
 @interface AppDelegate : UIResponder <UIApplicationDelegate>
 
 @property (strong, nonatomic) UIWindow *window;
-@property (strong, nonatomic) BaseViewController *viewController;
 
-// Holds all of the rail stations
+/**
+ Holds all of the rail stations
+*/
 @property (strong, nonatomic) NSMutableArray *stations;
-
-// WhistleBlower easter egg
-@property (strong, nonatomic) WhistleBlowerController *whistleBlower;
 @property (nonatomic) BOOL playSounds;
-
-- (void)test;
-- (void)initStations;
-
-// Set up audio for whistleblower
-- (void)initializeAudio;
-- (void)initializePreferences;
-- (void)configureAudioSession;
 
 @end

--- a/DenverRail/AppDelegate.m
+++ b/DenverRail/AppDelegate.m
@@ -6,61 +6,53 @@
 //
 
 #import "AppDelegate.h"
-#import "BaseViewController.h"
 #import "TimetableSearchUtility.h"
 #import "WhistleBlowerController.h"
 #import <AudioToolbox/AudioServices.h>
 
-NSString static *kPlaySoundsKey = @"playSoundsKey";
-NSString static *kPreferencesSetKey = @"prefsSet";
-NSString static *kPreferencesSetValue = @"prefsSet";
+static NSString *const kPlaySoundsKey = @"playSoundsKey";
+static NSString *const kPreferencesSetKey = @"prefsSet";
+static NSString *const kPreferencesSetValue = @"prefsSet";
+
+@interface AppDelegate()
+
+/**
+ WhistleBlower easter egg
+ */
+@property (strong, nonatomic) WhistleBlowerController *whistleBlower;
+
+@end
 
 @implementation AppDelegate
 
-@synthesize window = _window;
-@synthesize viewController = _viewController;
-@synthesize stations;
-@synthesize whistleBlower;
-@synthesize playSounds;
-
-// Starts the application 
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
         
     [[UIApplication sharedApplication] setStatusBarStyle:UIStatusBarStyleLightContent animated:NO];
     
-    [self initializePreferences];
+    [self initializeAudioPreferences];
     [self initializeAudio];
     [self initStations];
-    
-//    [TestFlight takeOff:@"8c164a2e084013eae880e49cf6a4e005_NTU1MTAyMDEyLTAzLTIyIDE4OjE2OjE5LjAzNzQ2OA"];
 	
     return YES;
 }
 
 // Checks sound when application comes from foreground 
 - (void)applicationDidBecomeActive:(UIApplication *)application {
-    [self initializePreferences];
-    NSLog(@" Play sounds is %@", (self.playSounds ? @"ON" : @"OFF")); 
+    [self initializeAudioPreferences];
     [self configureAudioSession];
 }
 
 // Initializes the audio for the first time
 - (void)initializeAudio {
-//    AudioSessionInitialize(NULL, NULL, NULL, NULL);
 	[AVAudioSession sharedInstance];
     self.whistleBlower = [[WhistleBlowerController alloc] init];
     [self configureAudioSession];
-//    AudioSessionSetActive(YES);
 	NSError *error = [[NSError alloc] init];
 	[[AVAudioSession sharedInstance] setActive:YES error:&error];
 }
 
 // Configures the audio session
 - (void) configureAudioSession {
-//    UInt32 otherAudioIsPlaying;
-//    UInt32 propertySize = sizeof(otherAudioIsPlaying);
-//	  AudioSessionGetProperty(kAudioSessionProperty_OtherAudioIsPlaying, &propertySize, &otherAudioIsPlaying);
-	
 	BOOL isPlayingWithOthers = [[AVAudioSession sharedInstance] isOtherAudioPlaying];
 	NSError *error = [[NSError alloc] init];
     
@@ -70,154 +62,111 @@ NSString static *kPreferencesSetValue = @"prefsSet";
         [[AVAudioSession sharedInstance] setCategory:AVAudioSessionCategorySoloAmbient error:&error];
     }
     
-    self.whistleBlower.on = NO;
-    
-//	if (otherAudioIsPlaying && self.playSounds) {
-    //if (isPlayingWithOthers && self.playSounds) {
-		
-        // Let our sounds blend with theirs in a beautiful melody.
-//        UInt32 category = kAudioSessionCategory_AmbientSound;
-//        AudioSessionSetProperty(kAudioSessionProperty_AudioCategory, sizeof(category), &category);
-		
-		//[[AVAudioSession sharedInstance] setCategory:AVAudioSessionCategoryAmbient error:&error];
-        
-        //self.whistleBlower.on = NO;
-
-    //} else if(self.playSounds) {
-        
-        // Enable playing and recording in the audio session so the Train whistle sillyness can take place.
-//        UInt32 category = kAudioSessionCategory_PlayAndRecord;
-//        AudioSessionSetProperty(kAudioSessionProperty_AudioCategory, sizeof(category), &category);
-		//[[AVAudioSession sharedInstance] setCategory:AVAudioSessionCategoryPlayAndRecord withOptions:AVAudioSessionCategoryOptionMixWithOthers error:&error];
-		
-//        UInt32 allowMixing = true; 
-//        AudioSessionSetProperty(kAudioSessionProperty_OverrideCategoryMixWithOthers, sizeof(allowMixing), &allowMixing);
-//		[[AVAudioSession sharedInstance] setCategory:AVAudioSessionCategoryPlayAndRecord error:&error];
-		
-//        UInt32 defaultToSpeaker = kAudioSessionProperty_OverrideCategoryDefaultToSpeaker;
-//        AudioSessionSetProperty(kAudioSessionProperty_OverrideCategoryDefaultToSpeaker, sizeof(defaultToSpeaker), &defaultToSpeaker);
-		
-		//[[AVAudioSession sharedInstance] overrideOutputAudioPort:AVAudioSessionPortOverrideSpeaker error:&error];
-        
-        //self.whistleBlower.on = YES;
-    //} else {
-        //self.whistleBlower.on = NO;
-    //}
+    self.whistleBlower.isOn = NO;
 }
 
-// Tests the data
-- (void)test {
-    NSArray *result = [TimetableSearchUtility getTimetableWithStation:[self.stations objectAtIndex:0] directionIsNorth:NO];
-    
-    if(result)
-        NSLog(@"result count: %i", [result count]);
-    else
-        NSLog(@"no results (returned nil)");
-}
-
-// Initializes the stations with their image name, database name, coordinates, and
-// booleans if they are one direction only and if they are east and west instead of north and south
+/**
+ Initializes the stations with their image name, database name, coordinates, and
+ booleans if they are one direction only and if they are east and west instead of north and south
+ */
 - (void)initStations {
 	self.stations = [NSMutableArray new];
     
 	[self.stations addObject:[[Station alloc] initWithImageName:@"10th-osage" columnName:@"10th & Osage Station"
-                                                       latitude:39.7318 logitude:-105.0056 southOnly:NO northOnly:NO eastWest:NO]];
+                                                       latitude:39.7318 longitude:-105.0056 southOnly:NO northOnly:NO eastWest:NO]];
      [self.stations addObject:[[Station alloc] initWithImageName:@"16th-california" columnName:@"16th & California Station"
-                                                        latitude:39.744919 logitude:-104.992428 southOnly:NO northOnly:YES eastWest:NO]];
+                                                        latitude:39.744919 longitude:-104.992428 southOnly:NO northOnly:YES eastWest:NO]];
      [self.stations addObject:[[Station alloc] initWithImageName:@"16th-stout" columnName:@"16th & Stout Station"
-                                                        latitude:39.746166 logitude:-104.992759 southOnly:YES northOnly:NO eastWest:NO]];
+                                                        latitude:39.746166 longitude:-104.992759 southOnly:YES northOnly:NO eastWest:NO]];
      [self.stations addObject:[[Station alloc] initWithImageName:@"18th-california" columnName:@"18th & California Station"
-                                                        latitude:39.746767 logitude:-104.990028 southOnly:NO northOnly:YES eastWest:NO]];
+                                                        latitude:39.746767 longitude:-104.990028 southOnly:NO northOnly:YES eastWest:NO]];
      [self.stations addObject:[[Station alloc] initWithImageName:@"18th-stout" columnName:@"18th & Stout Station"
-                                                        latitude:39.748018 logitude:-104.990404 southOnly:YES northOnly:NO eastWest:NO]];
+                                                        latitude:39.748018 longitude:-104.990404 southOnly:YES northOnly:NO eastWest:NO]];
      [self.stations addObject:[[Station alloc] initWithImageName:@"20th-welton" columnName:@"20th & Welton Station"
-                                                        latitude:39.747926 logitude:-104.986889 southOnly:NO northOnly:NO eastWest:NO]];
+                                                        latitude:39.747926 longitude:-104.986889 southOnly:NO northOnly:NO eastWest:NO]];
      [self.stations addObject:[[Station alloc] initWithImageName:@"25th-welton" columnName:@"25th & Welton Station"
-                                                        latitude:39.753392 logitude:-104.979764 southOnly:NO northOnly:NO eastWest:NO]];
+                                                        latitude:39.753392 longitude:-104.979764 southOnly:NO northOnly:NO eastWest:NO]];
      [self.stations addObject:[[Station alloc] initWithImageName:@"27th-welton" columnName:@"27th & Welton Station"
-                                                       latitude:39.755233 logitude:-104.977370 southOnly:NO northOnly:NO eastWest:NO]];
+                                                       latitude:39.755233 longitude:-104.977370 southOnly:NO northOnly:NO eastWest:NO]];
       [self.stations addObject:[[Station alloc] initWithImageName:@"30th-downing" columnName:@"30th & Downing Station"
-                                                         latitude:39.758800 logitude:-104.973572 southOnly:NO northOnly:NO eastWest:NO]];
+                                                         latitude:39.758800 longitude:-104.973572 southOnly:NO northOnly:NO eastWest:NO]];
       [self.stations addObject:[[Station alloc] initWithImageName:@"alameda" columnName:@"Alameda Station"
-                                                         latitude:39.7084 logitude:-104.9929 southOnly:NO northOnly:NO eastWest:NO]];
+                                                         latitude:39.7084 longitude:-104.9929 southOnly:NO northOnly:NO eastWest:NO]];
       [self.stations addObject:[[Station alloc] initWithImageName:@"arapahoe" columnName:@"Arapahoe at Village Center Station"
-                                                         latitude:39.6002 logitude:-104.8884 southOnly:NO northOnly:NO eastWest:NO]];
+                                                         latitude:39.6002 longitude:-104.8884 southOnly:NO northOnly:NO eastWest:NO]];
       [self.stations addObject:[[Station alloc] initWithImageName:@"auraria-west" columnName:@"Auraria West Station"
-                                                         latitude:39.741300 logitude:-105.008970 southOnly:NO northOnly:NO eastWest:NO]];
+                                                         latitude:39.741300 longitude:-105.008970 southOnly:NO northOnly:NO eastWest:NO]];
       [self.stations addObject:[[Station alloc] initWithImageName:@"belleview" columnName:@"Belleview Station"
-                                                         latitude:39.6275 logitude:-104.9043 southOnly:NO northOnly:NO eastWest:NO]];
+                                                         latitude:39.6275 longitude:-104.9043 southOnly:NO northOnly:NO eastWest:NO]];
       [self.stations addObject:[[Station alloc] initWithImageName:@"colfax-auraria" columnName:@"Colfax at Auraria Station"
-                                                         latitude:39.7403 logitude:-105.0019 southOnly:NO northOnly:NO eastWest:NO]];
+                                                         latitude:39.7403 longitude:-105.0019 southOnly:NO northOnly:NO eastWest:NO]];
       [self.stations addObject:[[Station alloc] initWithImageName:@"colorado" columnName:@"Colorado Station"
-                                                         latitude:39.6796 logitude:-104.9377 southOnly:NO northOnly:NO eastWest:NO]];
+                                                         latitude:39.6796 longitude:-104.9377 southOnly:NO northOnly:NO eastWest:NO]];
       [self.stations addObject:[[Station alloc] initWithImageName:@"county-line" columnName:@"County Line Station"
-                                                         latitude:39.5617 logitude:-104.8722 southOnly:NO northOnly:NO eastWest:NO]];
+                                                         latitude:39.5617 longitude:-104.8722 southOnly:NO northOnly:NO eastWest:NO]];
       [self.stations addObject:[[Station alloc] initWithImageName:@"dayton" columnName:@"Dayton Station"
-                                                         latitude:39.6430 logitude:-104.8779 southOnly:NO northOnly:NO eastWest:NO]];
+                                                         latitude:39.6430 longitude:-104.8779 southOnly:NO northOnly:NO eastWest:NO]];
       [self.stations addObject:[[Station alloc] initWithImageName:@"decatur-federal" columnName:@"Decatur / Federal Station"
-                                                        latitude:39.735687 logitude:-105.024452 southOnly:NO northOnly:NO eastWest:YES]];
+                                                        latitude:39.735687 longitude:-105.024452 southOnly:NO northOnly:NO eastWest:YES]];
       [self.stations addObject:[[Station alloc] initWithImageName:@"dry-creek" columnName:@"Dry Creek Station"
-                                                         latitude:39.5788 logitude:-104.8765 southOnly:NO northOnly:NO eastWest:NO]];
+                                                         latitude:39.5788 longitude:-104.8765 southOnly:NO northOnly:NO eastWest:NO]];
       [self.stations addObject:[[Station alloc] initWithImageName:@"englewood" columnName:@"Englewood Station"
-                                                         latitude:39.6556 logitude:-104.9999 southOnly:NO northOnly:NO eastWest:NO]];
+                                                         latitude:39.6556 longitude:-104.9999 southOnly:NO northOnly:NO eastWest:NO]];
       [self.stations addObject:[[Station alloc] initWithImageName:@"evans" columnName:@"Evans Station"
-                                                         latitude:39.6776 logitude:-104.9928 southOnly:NO northOnly:NO eastWest:NO]];
+                                                         latitude:39.6776 longitude:-104.9928 southOnly:NO northOnly:NO eastWest:NO]];
       [self.stations addObject:[[Station alloc] initWithImageName:@"federal-center" columnName:@"Federal Center Station"
-                                                         latitude:39.711852 logitude:-105.125347 southOnly:NO northOnly:NO eastWest:YES]];
+                                                         latitude:39.711852 longitude:-105.125347 southOnly:NO northOnly:NO eastWest:YES]];
       [self.stations addObject:[[Station alloc] initWithImageName:@"garrison" columnName:@"Garrison Station"
-                                                         latitude:39.736608 logitude:-105.099811 southOnly:NO northOnly:NO eastWest:YES]];
+                                                         latitude:39.736608 longitude:-105.099811 southOnly:NO northOnly:NO eastWest:YES]];
       [self.stations addObject:[[Station alloc] initWithImageName:@"i25-broadway" columnName:@"I-25 & Broadway Station"
-                                                         latitude:39.701523 logitude:-104.990158 southOnly:NO northOnly:NO eastWest:NO]];
+                                                         latitude:39.701523 longitude:-104.990158 southOnly:NO northOnly:NO eastWest:NO]];
       [self.stations addObject:[[Station alloc] initWithImageName:@"jeffco-golden" columnName:@"Jeffco Government Center Station"
-                                                         latitude:39.726640 logitude:-105.201728 southOnly:NO northOnly:NO eastWest:YES]];
+                                                         latitude:39.726640 longitude:-105.201728 southOnly:NO northOnly:NO eastWest:YES]];
       [self.stations addObject:[[Station alloc] initWithImageName:@"knox" columnName:@"Knox Station"
-                                                         latitude:39.735687 logitude:-105.033303 southOnly:NO northOnly:NO eastWest:YES]];
+                                                         latitude:39.735687 longitude:-105.033303 southOnly:NO northOnly:NO eastWest:YES]];
       [self.stations addObject:[[Station alloc] initWithImageName:@"lamar" columnName:@"Lamar Station"
-                                                         latitude:39.736683 logitude:-105.066872 southOnly:NO northOnly:NO eastWest:YES]];
+                                                         latitude:39.736683 longitude:-105.066872 southOnly:NO northOnly:NO eastWest:YES]];
       [self.stations addObject:[[Station alloc] initWithImageName:@"lincoln" columnName:@"Lincoln Station"
-                                                         latitude:39.5459 logitude:-104.8696 southOnly:NO northOnly:NO eastWest:NO]];
+                                                         latitude:39.5459 longitude:-104.8696 southOnly:NO northOnly:NO eastWest:NO]];
       [self.stations addObject:[[Station alloc] initWithImageName:@"littleton-downtown" columnName:@"Littleton / Downtown Station"
-                                                         latitude:39.6119 logitude:-105.0149 southOnly:NO northOnly:NO eastWest:NO]];
+                                                         latitude:39.6119 longitude:-105.0149 southOnly:NO northOnly:NO eastWest:NO]];
       [self.stations addObject:[[Station alloc] initWithImageName:@"littleton-mineral" columnName:@"Littleton / Mineral Ave Station"
-                                                         latitude:39.5801 logitude:-105.0250 southOnly:NO northOnly:NO eastWest:NO]];
+                                                         latitude:39.5801 longitude:-105.0250 southOnly:NO northOnly:NO eastWest:NO]];
       [self.stations addObject:[[Station alloc] initWithImageName:@"louisiana-pearl" columnName:@"Louisiana & Pearl Station"
-                                                         latitude:39.6928 logitude:-104.9782 southOnly:NO northOnly:NO eastWest:NO]];
+                                                         latitude:39.6928 longitude:-104.9782 southOnly:NO northOnly:NO eastWest:NO]];
       [self.stations addObject:[[Station alloc] initWithImageName:@"nine-mile" columnName:@"Nine Mile Station"
-                                                         latitude:39.6575 logitude:-104.8450 southOnly:NO northOnly:NO eastWest:NO]];
+                                                         latitude:39.6575 longitude:-104.8450 southOnly:NO northOnly:NO eastWest:NO]];
       [self.stations addObject:[[Station alloc] initWithImageName:@"oak" columnName:@"Oak Station"
-                                                         latitude:39.737400 logitude:-105.120463 southOnly:NO northOnly:NO eastWest:YES]];
+                                                         latitude:39.737400 longitude:-105.120463 southOnly:NO northOnly:NO eastWest:YES]];
       [self.stations addObject:[[Station alloc] initWithImageName:@"orchard" columnName:@"Orchard Station"
-                                                         latitude:39.6134 logitude:-104.8961 southOnly:NO northOnly:NO eastWest:NO]];
+                                                         latitude:39.6134 longitude:-104.8961 southOnly:NO northOnly:NO eastWest:NO]];
       [self.stations addObject:[[Station alloc] initWithImageName:@"oxford-sheridan" columnName:@"Oxford - City of Sheridan Station"
-                                                         latitude:39.6429 logitude:-105.0048 southOnly:NO northOnly:NO eastWest:NO]];
+                                                         latitude:39.6429 longitude:-105.0048 southOnly:NO northOnly:NO eastWest:NO]];
       [self.stations addObject:[[Station alloc] initWithImageName:@"pepsi-center" columnName:@"Pepsi Center / Elitch Gardens Station"
-                                                         latitude:39.7486 logitude:-105.0096 southOnly:NO northOnly:NO eastWest:NO]];
+                                                         latitude:39.7486 longitude:-105.0096 southOnly:NO northOnly:NO eastWest:NO]];
       [self.stations addObject:[[Station alloc] initWithImageName:@"perry" columnName:@"Perry Station"
-                                                         latitude:39.734790 logitude:-105.040409 southOnly:NO northOnly:NO eastWest:YES]];
+                                                         latitude:39.734790 longitude:-105.040409 southOnly:NO northOnly:NO eastWest:YES]];
       [self.stations addObject:[[Station alloc] initWithImageName:@"red-rocks-college" columnName:@"Red Rocks Community College Station"
-                                                         latitude:39.725078 logitude:-105.152812 southOnly:NO northOnly:NO eastWest:YES]];
+                                                         latitude:39.725078 longitude:-105.152812 southOnly:NO northOnly:NO eastWest:YES]];
       [self.stations addObject:[[Station alloc] initWithImageName:@"sheridan" columnName:@"Sheridan Station"
-                                                         latitude:39.735147 logitude:-105.053616 southOnly:NO northOnly:NO eastWest:YES]];
+                                                         latitude:39.735147 longitude:-105.053616 southOnly:NO northOnly:NO eastWest:YES]];
       [self.stations addObject:[[Station alloc] initWithImageName:@"hampden-southmoor" columnName:@"Southmoor Station"
-                                                       latitude:39.6485 logitude:-104.91628 southOnly:NO northOnly:NO eastWest:NO]];
+                                                       latitude:39.6485 longitude:-104.91628 southOnly:NO northOnly:NO eastWest:NO]];
       [self.stations addObject:[[Station alloc] initWithImageName:@"mile-high" columnName:@"Sports Authority Field at Mile High Stat"
-                                                       latitude:39.7434 logitude:-105.0131 southOnly:NO northOnly:NO eastWest:NO]];
+                                                       latitude:39.7434 longitude:-105.0131 southOnly:NO northOnly:NO eastWest:NO]];
       [self.stations addObject:[[Station alloc] initWithImageName:@"convention-center" columnName:@"Theatre District/Convention Ctr Station"
-                                                       latitude:39.7437 logitude:-104.9963 southOnly:NO northOnly:NO eastWest:NO]];
+                                                       latitude:39.7437 longitude:-104.9963 southOnly:NO northOnly:NO eastWest:NO]];
       [self.stations addObject:[[Station alloc] initWithImageName:@"union-station" columnName:@"Union Station"
-                                                         latitude:39.7526 logitude:-105.0008 southOnly:NO northOnly:NO eastWest:NO]];
+                                                         latitude:39.7526 longitude:-105.0008 southOnly:NO northOnly:NO eastWest:NO]];
       [self.stations addObject:[[Station alloc] initWithImageName:@"university"columnName:@"University of Denver Station"
-                                                         latitude:39.6852 logitude:-104.9648 southOnly:NO northOnly:NO eastWest:NO]];
+                                                         latitude:39.6852 longitude:-104.9648 southOnly:NO northOnly:NO eastWest:NO]];
       [self.stations addObject:[[Station alloc] initWithImageName:@"lakewood-wadsworth" columnName:@"Wadsworth Station"
-                                                         latitude:39.736664 logitude:-105.099811 southOnly:NO northOnly:NO eastWest:YES]];
+                                                         latitude:39.736664 longitude:-105.099811 southOnly:NO northOnly:NO eastWest:YES]];
       [self.stations addObject:[[Station alloc] initWithImageName:@"yale" columnName:@"Yale Station"
-                                                         latitude:39.6686 logitude:-104.927 southOnly:NO northOnly:NO eastWest:NO]];
+                                                         latitude:39.6686 longitude:-104.927 southOnly:NO northOnly:NO eastWest:NO]];
 }
 
-// Sets up the audio preferences
-- (void) initializePreferences {
-//    NSString *prefsInitializedString = [[NSUserDefaults standardUserDefaults] stringForKey:kPreferencesSetKey];
-	
+- (void)initializeAudioPreferences {
         NSString *pathStr = [[NSBundle mainBundle] bundlePath];
 		NSString *settingsBundlePath = [pathStr stringByAppendingPathComponent:@"Settings.bundle"];
 		NSString *finalPath = [settingsBundlePath stringByAppendingPathComponent:@"Root.plist"];
@@ -234,7 +183,6 @@ NSString static *kPreferencesSetValue = @"prefsSet";
 			id defaultValue = [prefItem objectForKey:@"DefaultValue"];
 			if ([keyValueStr isEqualToString:kPlaySoundsKey]) {
                 playSoundDefault = defaultValue;
-              
 			}
 		}
         

--- a/DenverRail/BaseViewController.h
+++ b/DenverRail/BaseViewController.h
@@ -27,7 +27,9 @@
 @property (strong, nonatomic) IBOutlet UIImageView *bottomCapImageView;
 @property (strong, nonatomic) IBOutlet UIImageView * shadowAboveButtons;
 
-// Store all content in this subview that will adjust if statusbar is there or not
+/**
+ Store all content in this subview that will adjust if statusbar is there or not
+*/
 @property (weak, nonatomic) IBOutlet UIView *contentSubView;
 
 @property (weak) IBOutlet UIImageView *backgroundTop;
@@ -66,7 +68,6 @@
 @property (strong) SearchViewController *searchViewController;
 @property (strong) Station *stationToReturnToAfterSearchCancelled;
 
-// 
 -(IBAction)mapTapped;
 -(IBAction)autoTapped;
 -(IBAction)searchTapped;

--- a/DenverRail/BaseViewController.h
+++ b/DenverRail/BaseViewController.h
@@ -6,11 +6,7 @@
 //
 
 #import <UIKit/UIKit.h>
-#import "ScheduleViewController.h"
-#import "LocationManager.h"
-#import "Station.h"
 #import "SearchViewController.h"
-
 
 // Main view controller and booleans for each state of the application
 @interface BaseViewController : UIViewController <UIPickerViewDelegate, UIPickerViewDataSource, SearchStationDelegate> {
@@ -19,85 +15,5 @@
     BOOL isMapMode;
     BOOL isSearchMode;
 }
-
-@property (strong, nonatomic) IBOutlet UIView *buttonDivider;
-@property (strong, nonatomic) IBOutlet UIImageView *whiteBackground;
-
-@property (strong, nonatomic) IBOutlet UIImageView *listBackground;
-@property (strong, nonatomic) IBOutlet UIImageView *bottomCapImageView;
-@property (strong, nonatomic) IBOutlet UIImageView * shadowAboveButtons;
-
-/**
- Store all content in this subview that will adjust if statusbar is there or not
-*/
-@property (weak, nonatomic) IBOutlet UIView *contentSubView;
-
-@property (weak) IBOutlet UIImageView *backgroundTop;
-@property (weak) IBOutlet UIImageView *arrow;
-@property (weak) IBOutlet UIImageView *middleSection;
-@property (weak) IBOutlet UIView *stationNameView;
-@property (weak) UIView *stationNameImageViewToAnimate;
-@property (weak) IBOutlet UIView *topSection;
-@property (weak) IBOutlet UIButton *autoButton;
-@property (weak) IBOutlet UIButton *mapButton;
-@property (weak) IBOutlet UIButton *nbButton;
-@property (weak) IBOutlet UIButton *sbButton;
-@property (weak) IBOutlet UIButton *wbButton;
-@property (weak) IBOutlet UIView *topLevelSlider;
-@property (weak) IBOutlet UIScrollView *mapScrollView;
-@property (weak) IBOutlet UIPickerView *datePicker;
-
-// Schedule view class for displaying times 
-@property (strong) ScheduleViewController *scheduleViewController;
-
-// Singleton location manager for getting automatic location
-@property (weak) LocationManager *locationManager; 
-@property (strong) Station *currentStation;
-@property (strong) Station *lastUsedManualStation;
-@property (strong) NSTimer *currentTimer;
-@property (strong) IBOutlet UIView *pickerView;
-
-@property (weak) IBOutlet UILabel *dayOfWeekLabel;
-@property (weak) IBOutlet UILabel *timeLabel;
-
-@property (weak) IBOutlet UILabel *distanceLabel;
-
-@property (weak) IBOutlet UIWebView *pdfWebView;
-
-// Search view for when searching for a station 
-@property (strong) SearchViewController *searchViewController;
-@property (strong) Station *stationToReturnToAfterSearchCancelled;
-
--(IBAction)mapTapped;
--(IBAction)autoTapped;
--(IBAction)searchTapped;
--(IBAction)timeSelectTapped;
--(IBAction)northboundTapped;
--(IBAction)southboundTapped;
-
-// Date picker
--(IBAction)datePickerNowTapped;
--(IBAction)datePickerDoneTapped;
--(void)showPickerView;
--(void)hidePickerView;
--(void)updateManualDateLabels;
-
--(void)toggleManualMode;
--(void)positionUpdated;
--(void)headingUpdated;
--(void)changeLightboardTo:(Station *)_station;
--(void)animateLightboard;
--(BOOL)moveLightboardLeftOneLED;
--(void)resetAnimation;
--(void)resetAnimationPart2;
--(void)rotateArrow:(int)degrees;
--(void)clearLightboard;
--(void)placeBrokenLED:(NSTimer *)theTimer;
--(void)flickerBrokenLED:(NSTimer *)theTimer;
--(void)showTapToSearch;
--(void)showSearch;
--(void)locationDenied;
--(void)locationApproved;
--(void)checkButtons:(Station *)_station;
 
 @end

--- a/DenverRail/BaseViewController.m
+++ b/DenverRail/BaseViewController.m
@@ -157,7 +157,6 @@
 
 // Location Denied button was pressed
 - (void)locationDenied {
-	NSLog(@"LOCATION SERVICE ACCESS DENIED");
     self.arrow.hidden = YES;
     self.distanceLabel.hidden = YES;
     autoButton.alpha = .4;
@@ -167,15 +166,9 @@
 }
 
 - (void)locationApproved {
-	NSLog(@"LOCATION SERVICE ACCESS APPOROVED");
 	self.arrow.hidden = NO;
 	self.distanceLabel.hidden = NO;
 	autoButton.alpha = 1;
-}
-
-// If the webView for the map failed to load
-- (void)webView:(UIWebView *)webView didFailLoadWithError:(NSError *)error {
-    NSLog(@"error loading map pdf: %@", [error description]);
 }
 
 // This means the position has been updated in either modes
@@ -213,7 +206,6 @@
 
 // When the display heading for station is updated
 - (void)headingUpdated {
-    NSLog(@"heading updated");
     int stationBearing = 0;
     
     if (isAutoMode)
@@ -228,14 +220,11 @@
 
 // Turn the directional arrow
 - (void)rotateArrow:(int)degrees {
-    NSLog(@"rotating arrow");
 	arrow.transform = CGAffineTransformIdentity;
 	arrow.transform = CGAffineTransformMakeRotation(degrees*0.0174532925);
 }
 
-#pragma mark -
-#pragma mark Lightboard
-#pragma mark -
+#pragma mark - Lightboard -
 
 // Shows tap to search if not on a searched station 
 -(void)showTapToSearch {
@@ -339,7 +328,7 @@
 // Resets and returns NO if it's already at the left side
 -(BOOL)moveLightboardLeftOneLED {
     
-    if (abs(self.stationNameImageViewToAnimate.frame.origin.x - 2) <
+    if (fabs(self.stationNameImageViewToAnimate.frame.origin.x - 2) <
        (self.stationNameImageViewToAnimate.frame.size.width - stationNameView.frame.size.width)) {
         
         self.stationNameImageViewToAnimate.frame = CGRectMake(self.stationNameImageViewToAnimate.frame.origin.x - 4,
@@ -428,9 +417,7 @@
                                              @"times", brokenLED, @"brokenLED", nil] repeats:NO];
 }
 
-#pragma mark -
-#pragma mark - Buttons
-#pragma mark -
+#pragma mark - Buttons -
 
 // When the northbound/westbound button pressed
 -(IBAction)northboundTapped {
@@ -439,8 +426,6 @@
 
     self.nbButton.selected = YES;
     self.sbButton.selected = NO;
-
-    NSLog(@"north %i south %i", self.nbButton.selected, self.sbButton.selected);
 
     [self.scheduleViewController updateCellsWithDirection:isNorth];
 }
@@ -452,9 +437,6 @@
 
     self.sbButton.selected = YES;
     self.nbButton.selected = NO;
-
-    NSLog(@"north %i south %i", self.nbButton.selected, self.sbButton.selected);
-
     [self.scheduleViewController updateCellsWithDirection:isNorth];
 }
 
@@ -563,8 +545,10 @@
     [self.scheduleViewController updateCellsManualMode];
 }
 
-// Checks to see if the selected station shows the right buttons. Some need to have
-// different directions, and some need to only enable one direction
+/**
+ Checks to see if the selected station shows the right buttons. Some need to have
+ different directions, and some need to only enable one direction
+*/
 - (void)checkButtons:(Station *)_station {
     
     /* Checks to see if the selected station has only one direction. This dictates
@@ -713,9 +697,7 @@
 
 }
 
-#pragma mark -
-#pragma mark - Time Picker
-#pragma mark - 
+#pragma mark - Time Picker -
 
 // Time selection bar is pressed show time picker
 -(IBAction)timeSelectTapped {
@@ -792,14 +774,14 @@
     
     // Add the 0 if necessary
     if (minute < 10)
-        minuteString = [NSString stringWithFormat:@"0%i", minute];
+        minuteString = [NSString stringWithFormat:@"0%li", (long)minute];
     else
-        minuteString = [NSString stringWithFormat:@"%i", minute];
+        minuteString = [NSString stringWithFormat:@"%li", (long)minute];
     
     if (isPM)
-        timeLabel.text = [NSString stringWithFormat:@"%i:%@ PM", hour, minuteString];
+        timeLabel.text = [NSString stringWithFormat:@"%li:%@ PM", (long)hour, minuteString];
     else
-        timeLabel.text = [NSString stringWithFormat:@"%i:%@ AM", hour, minuteString];
+        timeLabel.text = [NSString stringWithFormat:@"%li:%@ AM", (long)hour, minuteString];
     
     NSCalendar *cal = [[NSCalendar alloc] initWithCalendarIdentifier:NSGregorianCalendar];
     [cal setTimeZone:[NSTimeZone timeZoneWithName:@"US/Mountain"]];
@@ -833,7 +815,6 @@
 
 // Display the time picker
 -(void)showPickerView {
-    NSLog(@"%s %@", __PRETTY_FUNCTION__, NSStringFromCGRect(self.pickerView.frame));
     if (self.pickerView.frame.origin.y >= [[UIScreen mainScreen] applicationFrame].size.height) {
         
         // Offscreen, so slide it up
@@ -904,12 +885,12 @@
             
         // Hour
 		case 1:
-			return [NSString stringWithFormat:@"%i", row+1];
+			return [NSString stringWithFormat:@"%li", row+1];
             
         // Minute
 		case 2:
             {
-                NSString *minute = [NSString stringWithFormat:@"%i", row];
+                NSString *minute = [NSString stringWithFormat:@"%li", (long)row];
                 if ([minute length] < 2)
                     minute = [NSString stringWithFormat:@"0%@", minute];
                 return minute;

--- a/DenverRail/BaseViewController.m
+++ b/DenverRail/BaseViewController.m
@@ -7,6 +7,7 @@
 
 #import "BaseViewController.h"
 #import "TimetableSearchUtility.h"
+#import "LocalizedStrings.h"
 #import "ScheduleViewController.h"
 #import "LocationManager.h"
 
@@ -630,11 +631,11 @@
     
     // Changes from north south to east west
     if (_station.eastWest) {
-        [self.sbButton setTitle:@"Eastbound" forState:UIControlStateNormal];
-        [self.nbButton setTitle:@"Westbound" forState:UIControlStateNormal];
+        [self.sbButton setTitle:[LocalizedStrings eastbound] forState:UIControlStateNormal];
+        [self.nbButton setTitle:[LocalizedStrings westbound] forState:UIControlStateNormal];
     } else {
-        [self.sbButton setTitle:@"Southbound" forState:UIControlStateNormal];
-        [self.nbButton setTitle:@"Northbound" forState:UIControlStateNormal];
+        [self.sbButton setTitle:[LocalizedStrings southbound] forState:UIControlStateNormal];
+        [self.nbButton setTitle:[LocalizedStrings northbound] forState:UIControlStateNormal];
     }
 }
 
@@ -751,7 +752,7 @@
     NSCalendar *calendar = [[NSCalendar alloc] initWithCalendarIdentifier:NSGregorianCalendar];
     
     // Always use mountain no matter where we are
-    [calendar setTimeZone:[NSTimeZone timeZoneWithName:@"US/Mountain"]];
+    [calendar setTimeZone:[NSTimeZone timeZoneWithName:MountainTimeZone]];
     NSDateComponents *nowComponents = [calendar components:
                                        (NSWeekdayCalendarUnit | NSHourCalendarUnit | NSMinuteCalendarUnit) fromDate:now];
     
@@ -804,11 +805,11 @@
     BOOL isPM = [self.datePicker selectedRowInComponent:3] == 0 ? NO : YES;
     
     switch (dayOfWeek) {
-        case 0: self.dayOfWeekLabel.text = @"Weekday"; break;
-        case 1: self.dayOfWeekLabel.text = @"Friday"; break;
-        case 2: self.dayOfWeekLabel.text = @"Saturday"; break;
-        case 3: self.dayOfWeekLabel.text = @"Sunday"; break;
-        case 4: self.dayOfWeekLabel.text = @"Holiday";
+        case 0: self.dayOfWeekLabel.text = [LocalizedStrings weekday]; break;
+        case 1: self.dayOfWeekLabel.text = [LocalizedStrings friday]; break;
+        case 2: self.dayOfWeekLabel.text = [LocalizedStrings saturday]; break;
+        case 3: self.dayOfWeekLabel.text = [LocalizedStrings sunday]; break;
+        case 4: self.dayOfWeekLabel.text = [LocalizedStrings holiday];
     }
     
     NSString *minuteString = nil;
@@ -825,9 +826,9 @@
         self.timeLabel.text = [NSString stringWithFormat:@"%li:%@ AM", (long)hour, minuteString];
     
     NSCalendar *cal = [[NSCalendar alloc] initWithCalendarIdentifier:NSGregorianCalendar];
-    [cal setTimeZone:[NSTimeZone timeZoneWithName:@"US/Mountain"]];
+    [cal setTimeZone:[NSTimeZone timeZoneWithName:MountainTimeZone]];
     NSDateComponents *comps = [NSDateComponents new];
-    [comps setTimeZone:[NSTimeZone timeZoneWithName:@"US/Mountain"]];
+    [comps setTimeZone:[NSTimeZone timeZoneWithName:MountainTimeZone]];
     
     [comps setYear:2013];
     [comps setMonth:1];
@@ -917,11 +918,11 @@
 	switch(component) {
 		case 0:
 			switch (row) {
-				case 0: return @"Weekday";
-                case 1: return @"Friday";
-				case 2: return @"Saturday";
-				case 3: return @"Sunday";
-				case 4: return @"Holiday";
+				case 0: return [LocalizedStrings weekday];
+                case 1: return [LocalizedStrings friday];
+                case 2: return [LocalizedStrings saturday];
+                case 3: return [LocalizedStrings sunday];
+                case 4: return [LocalizedStrings holiday];
 			}
             
         // Hour

--- a/DenverRail/LocalizedStrings.h
+++ b/DenverRail/LocalizedStrings.h
@@ -1,0 +1,27 @@
+//
+//  LocalizedStrings.h
+//  denverrail
+//
+//  Created by Naomi Himley on 3/28/16.
+//  Copyright © 2016 Tack Mobile. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+@interface LocalizedStrings : NSObject
+
++ (NSString *)weekday;
++ (NSString *)friday;
++ (NSString *)saturday;
++ (NSString *)sunday;
++ (NSString *)holiday;
++ (NSString *)lessThanOneMinute;
++ (NSString *)moreThanOneMinuteFormatString;
++ (NSString *)notice;
++ (NSString *)nonEndOfLineRoute;
++ (NSString *)close;
++ (NSString *)northbound;
++ (NSString *)southbound;
++ (NSString *)eastbound;
++ (NSString *)westbound;
+@end

--- a/DenverRail/LocalizedStrings.m
+++ b/DenverRail/LocalizedStrings.m
@@ -1,0 +1,97 @@
+//
+//  LocalizedStrings.m
+//  denverrail
+//
+//  Created by Naomi Himley on 3/28/16.
+//  Copyright © 2016 Tack Mobile. All rights reserved.
+//
+
+#import "LocalizedStrings.h"
+
+@implementation LocalizedStrings
+
++ (NSString *)weekday
+{
+    return NSLocalizedString(@"Weekday",
+                             @"Title for 'weekday' choice in schedule type dropdown");
+}
+
++ (NSString *)friday
+{
+    return NSLocalizedString(@"Friday",
+                             @"Title for 'Friday' choice in schedule type dropdown");
+}
+
++ (NSString *)saturday
+{
+    return NSLocalizedString(@"Saturday",
+                             @"Title for 'Saturday' choice in schedule type dropdown");
+}
+
++ (NSString *)sunday
+{
+    return NSLocalizedString(@"Sunday",
+                             @"Title for 'Sunday' choice in schedule type dropdown");
+}
+
++ (NSString *)holiday
+{
+    return NSLocalizedString(@"Holiday",
+                             @"Title for 'Holiday' choice in schedule type dropdown");
+}
+
++ (NSString *)lessThanOneMinute
+{
+    return NSLocalizedString(@"< 1 Minute",
+                             @"Title for less than 1 minute remaining until train arrives");
+}
+
++ (NSString *)moreThanOneMinuteFormatString
+{
+    return NSLocalizedString(@"in %i Minutes%@",
+                             @"Title for more than 1 minute remaining until train arrivers");
+}
+
++ (NSString *)notice
+{
+    return NSLocalizedString(@"NOTICE",
+                             @"Title for Notice Alerts");
+}
+
++ (NSString *)nonEndOfLineRoute
+{
+    return NSLocalizedString(@"This route does not continue all the way to the end of the line.",
+                             @"Explanation text for non end of line routes");
+}
+
++ (NSString *)close
+{
+    return NSLocalizedString(@"Close",
+                             @"Button title for close button");
+}
+
++ (NSString *)northbound
+{
+    return NSLocalizedString(@"Northbound",
+                             @"Button title for north option");
+}
+
++ (NSString *)southbound
+{
+    return NSLocalizedString(@"Southbound",
+                             @"Button title for south option");
+}
+
++ (NSString *)eastbound
+{
+    return NSLocalizedString(@"Eastbound",
+                             @"Button title for east option");
+}
+
++ (NSString *)westbound
+{
+    return NSLocalizedString(@"Westbound",
+                             @"Button title for west option");
+}
+
+@end

--- a/DenverRail/LocationManager.h
+++ b/DenverRail/LocationManager.h
@@ -11,9 +11,7 @@
 
 @interface LocationManager : NSObject <CLLocationManagerDelegate> 
 
-@property (strong) CLLocationManager *locationManager;
 @property (strong) CLHeading *heading;
-@property (strong) CLLocation *location;
 @property (strong) Station *closestStation;
 @property (weak) NSMutableArray *stations;
 

--- a/DenverRail/LocationManager.m
+++ b/DenverRail/LocationManager.m
@@ -8,10 +8,14 @@
 #import "LocationManager.h"
 #import "AppDelegate.h"
 
+@interface LocationManager()
+
+@property (strong) CLLocation *location;
+@property (strong) CLLocationManager *locationManager;
+
+@end
+
 @implementation LocationManager
-@synthesize locationManager;
-@synthesize heading, location;
-@synthesize stations, closestStation;
 
 static LocationManager *sharedSingleton;
 
@@ -36,8 +40,6 @@ static LocationManager *sharedSingleton;
 		
 		// Attempt to fire up location services based on availability and authorization
 		[sharedSingleton activateLocationServices];
-        
-        NSLog(@"LOCATION MANAGER INITIALIZED");
     }
 }
 
@@ -46,9 +48,7 @@ static LocationManager *sharedSingleton;
     return sharedSingleton;
 }
 
-#pragma mark -
-#pragma mark CLLocationManagerDelegate methods
-#pragma mark -
+#pragma mark - CLLocationManagerDelegate methods -
 
 // Updates the heading for location 
 - (void)locationManager:(CLLocationManager *)manager didUpdateHeading:(CLHeading *)newHeading {
@@ -71,8 +71,7 @@ static LocationManager *sharedSingleton;
     }
     
     [[NSNotificationCenter defaultCenter] postNotificationName:@"locationUpdated" object:nil];
-    
-    NSLog(@"new location");
+
 }
 
 - (void)locationManager:(CLLocationManager *)manager didFailWithError:(NSError *)error {
@@ -89,9 +88,7 @@ static LocationManager *sharedSingleton;
 	}
 }
 
-#pragma mark -
-#pragma mark Activating and deactivating location services methods
-#pragma mark -
+#pragma mark - Activating and deactivating location services methods -
 
 - (void)activateLocationServices {
 	
@@ -151,13 +148,10 @@ static LocationManager *sharedSingleton;
 	[[NSNotificationCenter defaultCenter] postNotificationName:@"locationApproved" object:nil];
 }
 
-#pragma mark -
-#pragma mark Heading and distance methods
-#pragma mark -
+#pragma mark - Heading and distance methods -
 
 // Shows the display heading calibration
 - (BOOL)locationManagerShouldDisplayHeadingCalibration:(CLLocationManager *)manager {
-    NSLog(@"ignoring request to calibrate heading");
     return NO;
 }
 
@@ -189,10 +183,10 @@ static LocationManager *sharedSingleton;
         return -1;
     
     // Coordinates in radians
-    double lat1 = (location.coordinate.latitude * (3.14159265 / 180));
-    double long1 = (location.coordinate.longitude * (3.14159265 / 180));
-    double lat2 = (closestStation.latitude * (3.14159265 / 180));
-    double long2 = (closestStation.longitude * (3.14159265 / 180));
+    double lat1 = (self.location.coordinate.latitude * (3.14159265 / 180));
+    double long1 = (self.location.coordinate.longitude * (3.14159265 / 180));
+    double lat2 = (self.closestStation.latitude * (3.14159265 / 180));
+    double long2 = (self.closestStation.longitude * (3.14159265 / 180));
     
     // Do the calculations to determine direction
     double y = sin(long2-long1)*cos(lat2);
@@ -215,8 +209,8 @@ static LocationManager *sharedSingleton;
         return -1;
     
     // Coordinates in radians
-    double lat1 = (location.coordinate.latitude * (3.14159265 / 180));
-    double long1 = (location.coordinate.longitude * (3.14159265 / 180));
+    double lat1 = (self.location.coordinate.latitude * (3.14159265 / 180));
+    double long1 = (self.location.coordinate.longitude * (3.14159265 / 180));
     double lat2 = (_station.latitude * (3.14159265 / 180));
     double long2 = (_station.longitude * (3.14159265 / 180));
     

--- a/DenverRail/ScheduleViewController.h
+++ b/DenverRail/ScheduleViewController.h
@@ -15,7 +15,7 @@
 @property BOOL isNorthManual;
 @property BOOL isAutoMode;
 @property BOOL firstLoc;
-@property (weak) LocationManager *locationManager; //singleton
+@property (weak) LocationManager *sharedLocationManager; //singleton
 @property (strong) NSArray *currentStops;
 @property (strong) Station *currentManualStation;
 @property (strong) NSDate *currentManualDate;
@@ -24,11 +24,7 @@
 
 - (void)updateCellsAutoMode;
 - (void)updateCellsManualMode;
-- (void)updateCellsAutoModeIsNorth:(BOOL)_isNorth;
-- (void)updateCellsManualModeWithStation:(Station *)_station date:(NSDate *)_date;
-- (void)updateCellsManualModeWithStation:(Station *)_station date:(NSDate *)_date direction:(BOOL)_isNorth;
 - (void)updateCellsWithDirection:(BOOL)_isNorth;
-- (void)clearCells;
 - (void)playFlipsSound;
 
 

--- a/DenverRail/ScheduleViewController.h
+++ b/DenverRail/ScheduleViewController.h
@@ -9,6 +9,8 @@
 #import "LocationManager.h"
 #import <AVFoundation/AVFoundation.h>
 
+FOUNDATION_EXPORT NSString *const MountainTimeZone;
+
 @interface ScheduleViewController : UIViewController
 
 @property BOOL isNorthAuto;

--- a/DenverRail/ScheduleViewController.m
+++ b/DenverRail/ScheduleViewController.m
@@ -11,8 +11,11 @@
 #import <QuartzCore/QuartzCore.h>
 #import "Math.h"
 #import "AppDelegate.h"
+#import "LocalizedStrings.h"
 
 //TODO: Possibly look into having this VC use a tableview
+NSString *const MountainTimeZone = @"US/Mountain";
+
 @implementation ScheduleViewController
 @synthesize sharedLocationManager, isNorthAuto, isNorthManual, currentStops, isAutoMode, firstLoc;
 @synthesize currentManualDate, currentManualStation;
@@ -216,9 +219,9 @@
             relativeTimeLabel.font = [UIFont boldSystemFontOfSize:16];
             
             if (interval/60 < 1.0) {
-                relativeTimeLabel.text = [NSString stringWithFormat:@"< 1 Minute"];
+                relativeTimeLabel.text = [LocalizedStrings lessThanOneMinute];
             } else {
-                relativeTimeLabel.text = [NSString stringWithFormat:@"in %i Minutes%@", (int)round(interval / 60), currentStop.isHighlighted ? @"*" : @""];
+                relativeTimeLabel.text = [NSString stringWithFormat:[LocalizedStrings moreThanOneMinuteFormatString], (int)round(interval / 60), currentStop.isHighlighted ? @"*" : @""];
             }
             
             [cellBg addSubview:relativeTimeLabel];
@@ -230,7 +233,7 @@
             absoluteTimeLabel.font = [UIFont systemFontOfSize:14];
           
             NSDateFormatter *dateFormatter = [NSDateFormatter new];
-            [dateFormatter setTimeZone:[NSTimeZone timeZoneWithName:@"US/Mountain"]];
+            [dateFormatter setTimeZone:[NSTimeZone timeZoneWithName:MountainTimeZone]];
             [dateFormatter setDateFormat:@"h:mm aa"];
           
             absoluteTimeLabel.text = [NSString stringWithFormat:@"%@", [dateFormatter stringFromDate:currentStop.date]];
@@ -240,7 +243,7 @@
         // If in manual mode display differently
         } else {
             NSDateFormatter *dateFormatter = [NSDateFormatter new];
-            [dateFormatter setTimeZone:[NSTimeZone timeZoneWithName:@"US/Mountain"]];
+            [dateFormatter setTimeZone:[NSTimeZone timeZoneWithName:MountainTimeZone]];
             [dateFormatter setDateFormat:@"h:mm aa"];
             
             UILabel *absoluteTimeLabel = [UILabel new];
@@ -322,10 +325,10 @@
           if([j isKindOfClass:[UILabel class]]){
             UILabel *newLbl = (UILabel *)j;
             if([newLbl.text containsString:@"*"]) {
-              UIAlertView *alert = [[UIAlertView alloc] initWithTitle:@"NOTICE"
-                                                              message:@"This route does not continue all the way to the end of the line."
+              UIAlertView *alert = [[UIAlertView alloc] initWithTitle:[LocalizedStrings notice]
+                                                              message:[LocalizedStrings nonEndOfLineRoute]
                                                              delegate:nil
-                                                    cancelButtonTitle:@"Close"
+                                                    cancelButtonTitle:[LocalizedStrings close]
                                                     otherButtonTitles:nil, nil];
               [alert show];
             }

--- a/DenverRail/ScheduledStop.h
+++ b/DenverRail/ScheduledStop.h
@@ -8,14 +8,14 @@
 #import <Foundation/Foundation.h>
 #import "Station.h"
 
-typedef enum {
-    kCLine,
+typedef NS_ENUM(NSUInteger, RailLine) {
+    kCLine = 0,
     kDLine,
     kELine,
     kFLine,
     kHLine,
     kWLine
-} RailLine;
+};
 
 @interface ScheduledStop : NSObject
 

--- a/DenverRail/ScheduledStop.m
+++ b/DenverRail/ScheduledStop.m
@@ -8,6 +8,5 @@
 #import "ScheduledStop.h"
 
 @implementation ScheduledStop
-@synthesize date, line, isNorth, station;
 
 @end

--- a/DenverRail/SearchViewController.h
+++ b/DenverRail/SearchViewController.h
@@ -9,22 +9,15 @@
 #import "Station.h"
 
 @protocol SearchStationDelegate <NSObject>
-@required
+
 - (void)searchStationSelected:(Station *)stationName;
 - (void)searchCancelTapped;
+
 @end
 
 @interface SearchViewController : UIViewController <UITextFieldDelegate, UITableViewDelegate, UITableViewDataSource>
 
-@property (weak) IBOutlet UITextField *searchBoxTextField;
 @property (strong) NSObject <SearchStationDelegate> *delegate;
-@property (weak) IBOutlet UITableView *tableView;
-@property (weak) NSArray *allStations;
-@property (strong) NSMutableArray *matchingStations;
-
-- (IBAction)doneEditing:(UITextField *)_textField;
-- (IBAction)textFieldChanged:(id)sender;
-- (IBAction)cancelTapped:(id)sender;
 - (void)showKeyboard;
 
 @end

--- a/DenverRail/SearchViewController.m
+++ b/DenverRail/SearchViewController.m
@@ -11,22 +11,22 @@
 
 @interface SearchViewController ()
 
+@property (weak) IBOutlet UITextField *searchBoxTextField;
+@property (weak) IBOutlet UITableView *tableView;
+@property (weak) NSArray *allStations;
+@property (strong) NSMutableArray *matchingStations;
+
 @end
 
 @implementation SearchViewController
-@synthesize searchBoxTextField, tableView;
-@synthesize delegate;
-@synthesize allStations, matchingStations;
 
-
-// When the view is loaded
 - (void)viewDidLoad {
     [super viewDidLoad];
     
     AppDelegate *ad = (AppDelegate *)[[UIApplication sharedApplication] delegate];
     self.allStations = ad.stations;
     self.matchingStations = [NSMutableArray new];
-    [matchingStations addObjectsFromArray:allStations];
+    [self.matchingStations addObjectsFromArray:self.allStations];
     
     // Notifications on keyboard events 
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(keyboardWasShown:) name:UIKeyboardDidShowNotification object:nil];
@@ -41,51 +41,52 @@
 
 // When the cancel button is pressed
 - (IBAction)cancelTapped:(id)sender {
-    searchBoxTextField.text = @"";
-    [searchBoxTextField resignFirstResponder];
+    self.searchBoxTextField.text = @"";
+    [self.searchBoxTextField resignFirstResponder];
     [self.delegate searchCancelTapped];
 }
 
 // When the user enters in text for search
 - (IBAction)textFieldChanged:(id)sender {
     
-    [matchingStations removeAllObjects];
+    [self.matchingStations removeAllObjects];
     
-    if ([searchBoxTextField.text isBlank])
-        [matchingStations addObjectsFromArray:allStations];
-    else
+    if ([self.searchBoxTextField.text isBlank]) {
+        [self.matchingStations addObjectsFromArray:self.allStations];
+    } else {
 
         // Find all matching stations
-        for(Station *currentStation in allStations) {
-            if ([[currentStation.columnName lowercaseString] contains:[searchBoxTextField.text lowercaseString]]) {
-                    [matchingStations addObject:currentStation];
+        for(Station *currentStation in self.allStations) {
+            if ([[currentStation.columnName lowercaseString] contains:[self.searchBoxTextField.text lowercaseString]]) {
+                    [self.matchingStations addObject:currentStation];
             }
         }
-    
-    // Station name Wadsworth - Lakewood is in database as only wadsworth. Last item in both arrays is that station
-    if ([searchBoxTextField.text contains:@"l"]) {
-        [matchingStations addObject:[allStations lastObject]];
     }
     
-    [tableView reloadData];
+    // Station name Wadsworth - Lakewood is in database as only wadsworth. Last item in both arrays is that station
+    if ([self.searchBoxTextField.text contains:@"l"]) {
+        [self.matchingStations addObject:[self.allStations lastObject]];
+    }
+
+    [self.tableView reloadData];
 }
 
 // When the user is done searching
 - (IBAction)doneEditing:(UITextField *)_textField {
-    [searchBoxTextField resignFirstResponder];
+    [self.searchBoxTextField resignFirstResponder];
 }
 
 // When the user selects a station from the table 
-- (void)tableView:(UITableView *)_tableView didSelectRowAtIndexPath:(NSIndexPath *)indexPath {
-    [_tableView deselectRowAtIndexPath:indexPath animated:YES];
-    [searchBoxTextField resignFirstResponder];
+- (void)tableView:(UITableView *)tableView didSelectRowAtIndexPath:(NSIndexPath *)indexPath {
+    [tableView deselectRowAtIndexPath:indexPath animated:YES];
+    [self.searchBoxTextField resignFirstResponder];
     
-    [delegate searchStationSelected:[self.matchingStations objectAtIndex:indexPath.row]];
+    [self.delegate searchStationSelected:[self.matchingStations objectAtIndex:indexPath.row]];
 }
 
 // Shows the list of matching stations
-- (UITableViewCell *)tableView:(UITableView *)_tableView cellForRowAtIndexPath:(NSIndexPath *)indexPath {
-    UITableViewCell *cell = [_tableView dequeueReusableCellWithIdentifier:@"cell"];
+- (UITableViewCell *)tableView:(UITableView *)tableView cellForRowAtIndexPath:(NSIndexPath *)indexPath {
+    UITableViewCell *cell = [tableView dequeueReusableCellWithIdentifier:@"cell"];
     if (!cell) {
         cell = [[UITableViewCell alloc] initWithStyle:UITableViewCellStyleDefault reuseIdentifier:@"cell"];
     }
@@ -141,8 +142,8 @@
     
 }
 
-// When the view is unloaded
--(void)viewDidUnload {
+- (void)dealloc {
     [[NSNotificationCenter defaultCenter] removeObserver:self];
 }
+
 @end

--- a/DenverRail/Station.h
+++ b/DenverRail/Station.h
@@ -19,6 +19,12 @@
 @property (strong) CLLocation *location;
 @property (strong) UIImage *lightboardImage;
 
-- (id)initWithImageName:(NSString *)_imageName columnName:(NSString *)_columnName latitude:(double)_latitude logitude:(double)_longitude southOnly:(bool)_southOnly northOnly:(bool)_northOnly eastWest:(bool)_eastWest;
+- (id)initWithImageName:(NSString *)imageName
+             columnName:(NSString *)columnName
+               latitude:(double)latitude
+              longitude:(double)longitude
+              southOnly:(BOOL)southOnly
+              northOnly:(BOOL)northOnly
+               eastWest:(BOOL)eastWest;
 
 @end

--- a/DenverRail/Station.m
+++ b/DenverRail/Station.m
@@ -8,25 +8,25 @@
 #import "Station.h"
 
 @implementation Station
-@synthesize latitude, longitude, columnName, location, lightboardImage, southOnly, northOnly, eastWest;
 
-- (id)initWithImageName:(NSString *)_imageName columnName:(NSString *)_columnName
-               latitude:(double)_latitude logitude:(double)_longitude
-              southOnly:(bool)_southOnly northOnly:(bool)_northOnly
-               eastWest:(bool)_eastWest {
-    
-	self.lightboardImage = [UIImage imageNamed:_imageName];
-    
-    // If no image found
-    if(!self.lightboardImage)
-        NSLog(@"Error: no image found named %@", _imageName);
-	self.columnName = _columnName;
-	self.latitude = _latitude;
-	self.longitude = _longitude;
-    self.southOnly = _southOnly;
-    self.northOnly = _northOnly;
-    self.eastWest = _eastWest;
-	self.location = [[CLLocation alloc] initWithLatitude:_latitude longitude:_longitude];
+- (id)initWithImageName:(NSString *)imageName
+             columnName:(NSString *)columnName
+               latitude:(double)latitude
+               longitude:(double)longitude
+              southOnly:(BOOL)southOnly
+              northOnly:(BOOL)northOnly
+               eastWest:(BOOL)eastWest {
+    self = [super init];
+    if (self) {
+        _columnName = columnName;
+        _latitude = latitude;
+        _longitude = longitude;
+        _southOnly = southOnly;
+        _northOnly = northOnly;
+        _eastWest = eastWest;
+        _lightboardImage = [UIImage imageNamed:imageName];
+        _location = [[CLLocation alloc] initWithLatitude:latitude longitude:longitude];
+    }
     
 	return self;
 }

--- a/DenverRail/TimetableSearchUtility.m
+++ b/DenverRail/TimetableSearchUtility.m
@@ -8,6 +8,7 @@
 #import "TimetableSearchUtility.h"
 #import "FMDatabase.h"
 #import "ScheduledStop.h"
+#import "ScheduleViewController.h"
 #import "NSString+Common.h"
 
 @implementation TimetableSearchUtility
@@ -21,7 +22,7 @@
 +(NSArray *)getTimetableWithDate:(NSDate *)date andStation:(Station *)station directionIsNorth:(BOOL)isNorth {
     
     NSCalendar *calendar = [[NSCalendar alloc] initWithCalendarIdentifier:NSGregorianCalendar];
-    [calendar setTimeZone:[NSTimeZone timeZoneWithName:@"US/Mountain"]];
+    [calendar setTimeZone:[NSTimeZone timeZoneWithName:MountainTimeZone]];
     NSDateComponents *dateComponents = [calendar components:NSWeekdayCalendarUnit fromDate:date];
     NSInteger weekday = [dateComponents weekday];
 
@@ -107,7 +108,7 @@
         [tomorrowStops removeObjectsInArray:stops];
         [stops addObjectsFromArray:tomorrowStops];
         if ([stops count] > limitInt) {
-            for (NSInteger i = stops.count-1; i > 8; i--)
+            for (NSUInteger i = stops.count-1; i > 8; i--)
                 [stops removeLastObject];
         }
     }
@@ -259,7 +260,7 @@
 // NSDate to int value
 +(int)convertDateToInt:(NSDate *)date {
   NSDateFormatter *dateFormatter = [NSDateFormatter new];
-  [dateFormatter setTimeZone:[NSTimeZone timeZoneWithName:@"US/Mountain"]];
+  [dateFormatter setTimeZone:[NSTimeZone timeZoneWithName:MountainTimeZone]];
   [dateFormatter setDateFormat:@"HHmmss"];
   NSString *timeString = [dateFormatter stringFromDate:date];
   return [timeString intValue];
@@ -269,7 +270,7 @@
 +(NSDate *)convertDBDateIntToDate:(int)timeInt withCalendar:(NSCalendar *)calendar {
   // Assume today
   NSDateFormatter *dateFormatter = [NSDateFormatter new];
-  [dateFormatter setTimeZone:[NSTimeZone timeZoneWithName:@"US/Mountain"]];
+  [dateFormatter setTimeZone:[NSTimeZone timeZoneWithName:MountainTimeZone]];
   [dateFormatter setDateFormat:@"HHmmss"];
   
   NSString *dateString = nil;

--- a/DenverRail/TimetableSearchUtility.m
+++ b/DenverRail/TimetableSearchUtility.m
@@ -40,7 +40,6 @@
     FMDatabase *db = [FMDatabase databaseWithPath:path];
     
     if (![db open]) {
-        NSLog(@"error opening database");
         return nil;
     }
     
@@ -50,20 +49,15 @@
     else limitInt = 9;
     
     limit = [NSString stringWithFormat:@"%i", limitInt];
-  
-    NSLog(@"SELECT departure_time, route_id, stop_id FROM schedule WHERE stop_name = \"%@\" AND direction_id = %i AND departure_time > %i AND service_id = \"%@\" ORDER BY departure_time LIMIT 11", station.columnName, isNorth ? 0 : 1, timeInt, scheduleCode);
-  
+
     if (station.columnName == nil) {
       return nil; // If location is not initialized return empty set
     }
     
     FMResultSet *rs = [db executeQueryWithFormat:@"SELECT departure_time, route_id, stop_id FROM schedule WHERE stop_name = %@ AND direction_id = %i AND departure_time > %i AND service_id = %@ ORDER BY departure_time LIMIT %@", station.columnName, isNorth ? 0 : 1, timeInt, scheduleCode, limit];
-    NSLog(@"Query Error: %@", [db lastErrorMessage]);
     
     NSMutableArray *stops = [NSMutableArray new];
     while ([rs next]) {
-        NSLog(@"ROW: %i, %@, %i", [rs intForColumn:@"departure_time"], [rs stringForColumn:@"route_id"], [rs intForColumn:@"stop_id"]);
-
         int timeInt = [rs intForColumn:@"departure_time"];
         NSString *routeString = [rs stringForColumn:@"route_id"]; // c d e f h w
         int stopId = [rs intForColumn:@"stop_id"];
@@ -87,8 +81,6 @@
         if (line == kWLine && !isNorth) {
             isHighlighted = ![TimetableSearchUtility doesWTrainGoToEndStations:stopId atDepartureDate:dbDate withCalendar:calendar andWithDatabase:db];
         }
-      
-        NSLog(@"adding scheduled stop with date: %@", [dbDate description]);
 
         ScheduledStop *stop = [ScheduledStop new];
         stop.line = line;
@@ -115,7 +107,7 @@
         [tomorrowStops removeObjectsInArray:stops];
         [stops addObjectsFromArray:tomorrowStops];
         if ([stops count] > limitInt) {
-            for (int i=[stops count]-1; i > 8; i--)
+            for (NSInteger i = stops.count-1; i > 8; i--)
                 [stops removeLastObject];
         }
     }
@@ -123,7 +115,6 @@
     if ([stops count] > 0)
         return stops;
     return nil;
-    
 }
 
 +(BOOL)doesWTrainGoToEndStations:(int)currentStopId atDepartureDate:(NSDate *)date withCalendar:(NSCalendar *)calendar andWithDatabase:(FMDatabase *)db {
@@ -184,15 +175,9 @@
   
   // Find next train arrival
   
-  NSLog(@"SELECT departure_time, stop_name, stop_id FROM schedule WHERE route_id like '%%w%%' AND direction_id = 1 AND stop_id = %i AND departure_time > %i AND departure_time < %i ORDER BY departure_time LIMIT 1", nextStationId, departureInt, nextDepartureInt);
-  
   FMResultSet *rs = [db executeQueryWithFormat:@"SELECT departure_time, stop_name, stop_id FROM schedule WHERE route_id like '%%w%%' AND direction_id = 1 AND stop_id = %i AND departure_time > %i AND departure_time < %i ORDER BY departure_time LIMIT 1", nextStationId, departureInt, nextDepartureInt];
   
-  NSLog(@"Query Error: %@", [db lastErrorMessage]);
-  
   if ([rs next]) {
-    NSLog(@"ROW: %i, %@, %i", [rs intForColumn:@"departure_time"], [rs stringForColumn:@"stop_name"], [rs intForColumn:@"stop_id"]);
-    
     int actualDepartureTimeInt = [rs intForColumn:@"departure_time"];
     int stopId = [rs intForColumn:@"stop_id"];
     
@@ -290,9 +275,6 @@
   NSString *dateString = nil;
   if (timeInt > 239999)
     timeInt -= 240000;
-  
-  NSLog(@"time int: %i", timeInt);
-  
   if (timeInt > 99999)
     dateString = [NSString stringWithFormat:@"%i", timeInt];
   else if (timeInt < 1000)

--- a/DenverRail/WhistleBlowerController.h
+++ b/DenverRail/WhistleBlowerController.h
@@ -8,29 +8,20 @@
 #import <Foundation/Foundation.h>
 #import <AVFoundation/AVFoundation.h>
 
-enum WhistleBlowerState {
+typedef NS_ENUM(NSUInteger, WhistleBlowerState) {
     WhistleBlowerStateNoWhistleYet = 0,
-    WhistleBlowerStateOneWhistle = 1,
-    WhistleBlowerStateMultipleWhistles = 2
+    WhistleBlowerStateOneWhistle,
+    WhistleBlowerStateMultipleWhistles,
 };
 
-
 @interface WhistleBlowerController : NSObject<AVAudioPlayerDelegate> {
-    enum WhistleBlowerState state;
     double lastSample;
     int ticksSinceLastWhistle;
     BOOL whistlePlaying;
 }
 
-@property(nonatomic) BOOL on;
-@property(nonatomic, strong) AVAudioRecorder *recorder;
-@property(nonatomic, strong) NSTimer *timer;
-@property(nonatomic, strong) AVAudioPlayer *toot;
-@property(nonatomic, strong) AVAudioPlayer *shortWhistle;
-@property(nonatomic, strong) AVAudioPlayer *mediumWhistle;
-@property(nonatomic, strong) AVAudioPlayer *loudLongWhistle;
-@property(nonatomic, strong) AVAudioPlayer *currentPlayer;
-
-- (void) putYourLipsTogetherAndBlow;
+@property WhistleBlowerState currentState;
+@property(nonatomic) BOOL isOn;
+- (void)putYourLipsTogetherAndBlow;
 
 @end

--- a/denverrail.xcodeproj/project.pbxproj
+++ b/denverrail.xcodeproj/project.pbxproj
@@ -227,6 +227,7 @@
 		4C7775B919E2FD7F004FECD4 /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 4C7775B819E2FD7F004FECD4 /* Images.xcassets */; };
 		4C7775BD19E3023B004FECD4 /* Icon-40@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 4C7775BB19E3023B004FECD4 /* Icon-40@2x.png */; };
 		4C7775BE19E3023B004FECD4 /* Icon-60@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = 4C7775BC19E3023B004FECD4 /* Icon-60@3x.png */; };
+		8C366B951CA9DC1F000E73CD /* LocalizedStrings.m in Sources */ = {isa = PBXBuildFile; fileRef = 8C366B941CA9DC1F000E73CD /* LocalizedStrings.m */; };
 		9672835816B986DD000BECE6 /* Icon-72.png in Resources */ = {isa = PBXBuildFile; fileRef = 9672835516B986DD000BECE6 /* Icon-72.png */; };
 		9672835916B986DD000BECE6 /* Icon-72@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 9672835616B986DD000BECE6 /* Icon-72@2x.png */; };
 		9672835A16B986DD000BECE6 /* Icon-Small@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 9672835716B986DD000BECE6 /* Icon-Small@2x.png */; };
@@ -492,6 +493,8 @@
 		4C7775B819E2FD7F004FECD4 /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; name = Images.xcassets; path = ../denverrail/Images.xcassets; sourceTree = "<group>"; };
 		4C7775BB19E3023B004FECD4 /* Icon-40@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "Icon-40@2x.png"; sourceTree = SOURCE_ROOT; };
 		4C7775BC19E3023B004FECD4 /* Icon-60@3x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "Icon-60@3x.png"; sourceTree = SOURCE_ROOT; };
+		8C366B931CA9DC1F000E73CD /* LocalizedStrings.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LocalizedStrings.h; sourceTree = "<group>"; };
+		8C366B941CA9DC1F000E73CD /* LocalizedStrings.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = LocalizedStrings.m; sourceTree = "<group>"; };
 		9672835516B986DD000BECE6 /* Icon-72.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; name = "Icon-72.png"; path = "../Icon-72.png"; sourceTree = "<group>"; };
 		9672835616B986DD000BECE6 /* Icon-72@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; name = "Icon-72@2x.png"; path = "../Icon-72@2x.png"; sourceTree = "<group>"; };
 		9672835716B986DD000BECE6 /* Icon-Small@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; name = "Icon-Small@2x.png"; path = "../Icon-Small@2x.png"; sourceTree = "<group>"; };
@@ -577,6 +580,8 @@
 				39E6389414E1D306006FC1D6 /* NSString+Common.m */,
 				3912A92014E5CBE900AEF260 /* LocationManager.h */,
 				3912A92114E5CBE900AEF260 /* LocationManager.m */,
+				8C366B931CA9DC1F000E73CD /* LocalizedStrings.h */,
+				8C366B941CA9DC1F000E73CD /* LocalizedStrings.m */,
 			);
 			name = Utility;
 			sourceTree = "<group>";
@@ -1210,6 +1215,7 @@
 				39E7F10314DE45D9007C8617 /* TimetableSearchUtility.m in Sources */,
 				39E7F10614DE4646007C8617 /* Station.m in Sources */,
 				39226D8614E11B3B00ADF82A /* FMDatabase.m in Sources */,
+				8C366B951CA9DC1F000E73CD /* LocalizedStrings.m in Sources */,
 				39226D8714E11B3B00ADF82A /* FMDatabaseAdditions.m in Sources */,
 				39226D8814E11B3B00ADF82A /* FMDatabasePool.m in Sources */,
 				39226D8914E11B3B00ADF82A /* FMDatabaseQueue.m in Sources */,


### PR DESCRIPTION
… fixing compiler warnings, privatizing private methods and properties.
Using the /*\* documentation comments for comments describing what properties or methods do makes it so that you can right click on those things anywhere in code and it will show the comment.
Also fixed some spelling mistakes and updated to avoid using @synthesize where unnecessary.
The pragma mark updates create the same effect. 
@JanBo @RockNRoll08 Feel free to look over and let me know if there's anything you see that you don't like, otherwise I'll merge tomorrow.
